### PR TITLE
Fix membership expiration

### DIFF
--- a/vile_pilates/studio/utils.py
+++ b/vile_pilates/studio/utils.py
@@ -217,10 +217,11 @@ def import_payments_from_excel(file_obj) -> dict:
                     continue
 
                 # ---------- vigencia ----------
-                if not membership.classes_per_month:  # None o 0  ⇒  ilimitado-por-día
-                    valid_until = pay_dt.date()
-                else:
-                    valid_until = pay_dt.date() + timedelta(days=30)
+                # Todos los pagos importados deben tener una vigencia de 30 días
+                # a partir de la fecha de pago. Antes se asignaba la fecha del
+                # mismo día cuando ``classes_per_month`` era 0 o ``None`` y eso
+                # provocaba que las suscripciones caducaran inmediatamente.
+                valid_until = pay_dt.date() + timedelta(days=30)
 
                 # ---------- evitar duplicados ----------
                 dup = Payment.objects.filter(

--- a/vile_pilates/studio/views.py
+++ b/vile_pilates/studio/views.py
@@ -948,7 +948,11 @@ class PaymentViewSet(viewsets.ModelViewSet):
         if promo_instance:
             selected_promotion = promo_instance.promotion
 
-        valid_until = today if membership.classes_per_month == 0 else today + timedelta(days=30)
+        # Todos los pagos se registran con 30 días de vigencia a partir de la fecha de pago.
+        # Anteriormente, los planes con ``classes_per_month == 0`` se marcaban
+        # con vigencia del mismo día, lo cual provocaba vencimientos
+        # inmediatos y notificaciones erróneas.
+        valid_until = today + timedelta(days=30)
 
         payment = Payment.objects.create(
             client_id=client_id,


### PR DESCRIPTION
## Summary
- ensure payment validity always extends 30 days
- update import utility to use the same logic

## Testing
- `python vile_pilates/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68426e1f9960833084f7ef1d3f4e29d6