### PR TITLE
Fix booking limit calculations

### DIFF
--- a/vile_pilates/studio/management/mails/mails.py
+++ b/vile_pilates/studio/management/mails/mails.py
@@ -4,7 +4,6 @@ from django.conf import settings
 from django.utils import timezone
 from babel.dates import format_date
 from ...models import Booking
-from calendar import monthrange
 from decimal import Decimal
 
 
@@ -30,15 +29,9 @@ def send_booking_confirmation_email(booking):
 
     if client_obj.active_membership:
         plan = client_obj.active_membership
-        start_month = today.replace(day=1)
-        last_day = monthrange(today.year, today.month)[1]
-        end_month = today.replace(day=last_day)
+        from studio.utils import count_valid_monthly_bookings
 
-        bookings_this_month = Booking.objects.filter(
-            client=client_obj,
-            class_date__range=[start_month, end_month],
-            status='active'
-        ).count()
+        bookings_this_month = count_valid_monthly_bookings(client_obj)
 
         remaining = plan.classes_per_month - bookings_this_month
         extra_info = (

--- a/vile_pilates/studio/views.py
+++ b/vile_pilates/studio/views.py
@@ -258,15 +258,9 @@ class BookingViewSet(viewsets.ModelViewSet):
         latest_payment = Payment.objects.filter(client=client).order_by('-date_paid').first()
         if latest_payment:
             membership_plan = latest_payment.membership
-            today = timezone.now().date()
-            start_of_month = today.replace(day=1)
-            end_of_month = (start_of_month + timedelta(days=32)).replace(day=1) - timedelta(days=1)
+            from .utils import count_valid_monthly_bookings
 
-            monthly_bookings = Booking.objects.filter(
-                client=client,
-                class_date__range=[start_of_month, end_of_month],
-                status='active'
-            ).count()
+            monthly_bookings = count_valid_monthly_bookings(client)
 
             if latest_payment.promotion_id:
                 promotion = latest_payment.promotion


### PR DESCRIPTION
## Summary
- count valid monthly bookings excluding no-shows
- reuse booking count in booking creation and emails

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684270ac2730833098dd50590dbb8a52